### PR TITLE
Correct license link URL error.

### DIFF
--- a/page_footer.html
+++ b/page_footer.html
@@ -27,7 +27,7 @@
             <div>
                 <ul class="nav navbar-nav">
                     <li>
-                        <a href="http://blockly.parallax.com/blockly//public/license">License</a>
+                        <a href="http://blockly.parallax.com/blockly/public/license">License</a>
                     </li>
                     <li>
                         <a href="http://blockly.parallax.com/blockly/public/clientdownload">BlocklyProp Client Downloads</a>


### PR DESCRIPTION
Addresses issue parallaxinc/solo#22.

Apply correction identified in the issue. 
