### PR TITLE
Issue 26 block help links yield 500 error

### DIFF
--- a/blocklyc.html
+++ b/blocklyc.html
@@ -161,7 +161,7 @@
                                                     <li class="auth-true online-only" data-displayas="list-item"><a href="my/projects.jsp" class="url-prefix"><span class="keyed-lang-string" data-key="menu_my_projects"></span></a></li>
                                                     <li class="online-only"><a href="projects.jsp" class="url-prefix"><span class="keyed-lang-string" data-key="menu_community_projects"></span></a></li>
                                                     <li class="online-only divider"></li>
-                                                    <li><a href="public/help" target="_blank" class="url-prefix"><span class="keyed-lang-string" data-key="menu_help_reference"></span></a></li>
+                                                    <li><a href="https://learn.parallax.com/ab-blocks" target="_blank" class="url-prefix"><span class="keyed-lang-string" data-key="menu_help_reference"></span></a></li>
                                                     <li class="divider"></li>
                                                     <li><a id="download-side" href="#"><span class="keyed-lang-string" data-key="menu_download_simpleide"></span></a></li>
                                                     <li class="online-only divider" data-displayas="list-item"><a id="download-project" href="#"><span class="keyed-lang-string" data-key="editor_download"></span></a></li>


### PR DESCRIPTION
Corrects error with missing help files in the CDN library.